### PR TITLE
Fix battle intent bugs

### DIFF
--- a/_SampleUtterances.txt
+++ b/_SampleUtterances.txt
@@ -1,15 +1,9 @@
-ROLLDICEINTENT roll {numDice} d {numSides} {adding} {modifier}
 ROLLDICEINTENT roll me {numDice} d {numSides} {adding} {modifier}
-ROLLDICEINTENT generate {numDice} d {numSides} {adding} {modifier}
 ROLLDICEINTENT generate me {numDice} d {numSides} {adding} {modifier}
-ROLLDICEINTENT give {numDice} d {numSides} {adding} {modifier}
 ROLLDICEINTENT give me {numDice} d {numSides} {adding} {modifier}
 
-ROLLDICEINTENT roll {numDice} d {numSides}
 ROLLDICEINTENT roll me {numDice} d {numSides}
-ROLLDICEINTENT generate {numDice} d {numSides}
 ROLLDICEINTENT generate me {numDice} d {numSides} 
-ROLLDICEINTENT give {numDice} d {numSides} 
 ROLLDICEINTENT give me {numDice} d {numSides} 
 
 SIMULATEBATTLEINTENT simulate {numPartyOne} {partyOneType} vs {numPartyTwo} {partyTwoType}
@@ -36,7 +30,7 @@ CALCULATEPROBABILITYINTENT calculate the probability of {numPartyOne} {partyOneT
 CALCULATEPROBABILITYINTENT calculate the probability of {numPartyOne} {partyOneType} beating {numPartyTwo} {partyTwoType}
 CALCULATEPROBABILITYINTENT simulate the probability of {numPartyOne} {partyOneType} vs {numPartyTwo} {partyTwoType}
 CALCULATEPROBABILITYINTENT simulate the probability of {numPartyOne} {partyOneType} versus {numPartyTwo} {partyTwoType}
-CALCULATEPROBABILITYINTENT simualte the probability of {numPartyOne} {partyOneType} fighting {numPartyTwo} {partyTwoType}
+CALCULATEPROBABILITYINTENT simulate the probability of {numPartyOne} {partyOneType} fighting {numPartyTwo} {partyTwoType}
 CALCULATEPROBABILITYINTENT simulate the probability of {numPartyOne} {partyOneType} against {numPartyTwo} {partyTwoType}
 CALCULATEPROBABILITYINTENT simulate the probability of {numPartyOne} {partyOneType} beating {numPartyTwo} {partyTwoType}
 CALCULATEPROBABILITYINTENT what is the probability of {numPartyOne} {partyOneType} vs {numPartyTwo} {partyTwoType}


### PR DESCRIPTION
# Abstract
Fixed bugs in the battle intent.  Mainly this involved adding input validation. Added code to check for "value" slot presence before dereferencing.  If there are input errors, then respond with a notice that we couldn't understand the input.

For sample utterances, I removed half the utterances for Dice Logic because the Amazon skill processer simply couldn't figure out how to set `numDice` properly if the word "me" wasn't in the input.  So I removed the sample utterances without the word "me".  This is a bit drastic, but if we can figure out why this doesn't work, we can add back those other sample utterances.

# Testing
None other than the removal of the sample utterances.