### PR TITLE
Restore some of the fixes that got lost

### DIFF
--- a/GameHelperMain.py
+++ b/GameHelperMain.py
@@ -29,7 +29,13 @@ def get_welcome_response():
     """
     session_attributes = {}
     card_title = "Welcome"
-    speech_output = "I can help with dice and Risk."
+    speech_output = """
+    Welcome to Game Helper.
+    I can help you generate dice rolls of any number of dice, of any number of sides, while optionally adding a modifier to the roll.
+    I can also simulate battles of any number of attackers versus any number of defenders.
+    Finally, I can calculate the probability of winning a battle of 2 to 12 attackers versus 1 to 11 attackers.
+    Go ahead and ask me to roll dice, simulate battles, or calculate probabilities of winning.
+    """
 
     # If the user either does not reply to the welcome message or says something
     # that is not understood, they will be prompted again with this text.
@@ -37,6 +43,31 @@ def get_welcome_response():
     should_end_session = False
     return build_response(session_attributes, build_speechlet_response(
         card_title, speech_output, reprompt_text, should_end_session))
+
+def get_help_response():
+    """
+    Called if the user requests help
+    """
+    session_attributes = {}
+    card_title = "Help"
+    speech_output = """
+    I can help you generate dice rolls of any number of dice, of any number of sides, while optionally adding a modifier to the roll.
+    For example, you can say, roll me 5 die 6 plus 4.
+    I can also help simulate board game battle results similar to the game Risk.
+    I have two capabilities in this area.
+    First, I can simulate battles of any number of attackers versus any number of defenders.
+    For example, you can say, simulate 5 attackers versus 4 defenders.
+    Second, I can also calculate the probability of winning a battle of 2 to 12 attackers versus 1 to 11 attackers.
+    For example, you can say, find the probability of 10 attackers beating 7 defenders. 
+    """
+
+    # If the user either does not reply to the welcome message or says something
+    # that is not understood, they will be prompted again with this text.
+    reprompt_text = "Can I help you with your game?"
+    should_end_session = False
+    return build_response(session_attributes, build_speechlet_response(
+        card_title, speech_output, reprompt_text, should_end_session))
+
 
 def handle_session_end_request():
     """
@@ -90,7 +121,7 @@ def on_intent(intent_request, session):
         return battle_probability_handler(intent)
     # Amazon's built in intent types below:
     elif intent_name == "AMAZON.HelpIntent":
-        return get_welcome_response()
+        return get_help_response()
     elif intent_name == "AMAZON.CancelIntent" or intent_name == "AMAZON.StopIntent":
         return handle_session_end_request()
     else:

--- a/RiskLogic.py
+++ b/RiskLogic.py
@@ -37,7 +37,7 @@ def battle_handler(intent):
     session_attributes = {}
     # constructs and returns a completed Alexa response
     # note: no reprompt text is given because in the course of a game, a battle only runs once
-    return build_response(session_attributes, build_speechlet_response(card_title, battle_res_string, None, True))
+    return build_response(session_attributes, build_speechlet_response(card_title, battle_res_string, "", True))
 
 def battle_probability_handler(intent):
     intent = intent["slots"]

--- a/_SampleUtterances.txt
+++ b/_SampleUtterances.txt
@@ -1,15 +1,9 @@
-ROLLDICEINTENT roll {numDice} d {numSides} {adding} {modifier}
 ROLLDICEINTENT roll me {numDice} d {numSides} {adding} {modifier}
-ROLLDICEINTENT generate {numDice} d {numSides} {adding} {modifier}
 ROLLDICEINTENT generate me {numDice} d {numSides} {adding} {modifier}
-ROLLDICEINTENT give {numDice} d {numSides} {adding} {modifier}
 ROLLDICEINTENT give me {numDice} d {numSides} {adding} {modifier}
 
-ROLLDICEINTENT roll {numDice} d {numSides}
 ROLLDICEINTENT roll me {numDice} d {numSides}
-ROLLDICEINTENT generate {numDice} d {numSides}
 ROLLDICEINTENT generate me {numDice} d {numSides} 
-ROLLDICEINTENT give {numDice} d {numSides} 
 ROLLDICEINTENT give me {numDice} d {numSides} 
 
 SIMULATEBATTLEINTENT simulate {numPartyOne} {partyOneType} vs {numPartyTwo} {partyTwoType}
@@ -36,7 +30,7 @@ CALCULATEPROBABILITYINTENT calculate the probability of {numPartyOne} {partyOneT
 CALCULATEPROBABILITYINTENT calculate the probability of {numPartyOne} {partyOneType} beating {numPartyTwo} {partyTwoType}
 CALCULATEPROBABILITYINTENT simulate the probability of {numPartyOne} {partyOneType} vs {numPartyTwo} {partyTwoType}
 CALCULATEPROBABILITYINTENT simulate the probability of {numPartyOne} {partyOneType} versus {numPartyTwo} {partyTwoType}
-CALCULATEPROBABILITYINTENT simualte the probability of {numPartyOne} {partyOneType} fighting {numPartyTwo} {partyTwoType}
+CALCULATEPROBABILITYINTENT simulate the probability of {numPartyOne} {partyOneType} fighting {numPartyTwo} {partyTwoType}
 CALCULATEPROBABILITYINTENT simulate the probability of {numPartyOne} {partyOneType} against {numPartyTwo} {partyTwoType}
 CALCULATEPROBABILITYINTENT simulate the probability of {numPartyOne} {partyOneType} beating {numPartyTwo} {partyTwoType}
 CALCULATEPROBABILITYINTENT what is the probability of {numPartyOne} {partyOneType} vs {numPartyTwo} {partyTwoType}

--- a/_SampleUtterances.txt
+++ b/_SampleUtterances.txt
@@ -1,10 +1,16 @@
-ROLLDICEINTENT roll me {numDice} d {numSides} {adding} {modifier}
-ROLLDICEINTENT generate me {numDice} d {numSides} {adding} {modifier}
-ROLLDICEINTENT give me {numDice} d {numSides} {adding} {modifier}
+ROLLDICEINTENT roll {numDice} die {numSides} {adding} {modifier}
+ROLLDICEINTENT generate {numDice} die {numSides} {adding} {modifier}
+ROLLDICEINTENT give {numDice} die {numSides} {adding} {modifier}
+ROLLDICEINTENT roll me {numDice} die {numSides} {adding} {modifier}
+ROLLDICEINTENT generate me {numDice} die {numSides} {adding} {modifier}
+ROLLDICEINTENT give me {numDice} die {numSides} {adding} {modifier}
 
-ROLLDICEINTENT roll me {numDice} d {numSides}
-ROLLDICEINTENT generate me {numDice} d {numSides} 
-ROLLDICEINTENT give me {numDice} d {numSides} 
+ROLLDICEINTENT roll {numDice} die {numSides}
+ROLLDICEINTENT generate {numDice} die {numSides} 
+ROLLDICEINTENT give {numDice} die {numSides} 
+ROLLDICEINTENT roll me {numDice} die {numSides}
+ROLLDICEINTENT generate me {numDice} die {numSides} 
+ROLLDICEINTENT give me {numDice} die {numSides} 
 
 SIMULATEBATTLEINTENT simulate {numPartyOne} {partyOneType} vs {numPartyTwo} {partyTwoType}
 SIMULATEBATTLEINTENT simulate {numPartyOne} {partyOneType} versus {numPartyTwo} {partyTwoType}


### PR DESCRIPTION
# Abstract
Some of the changes from #2 were lost during a failed merge.  This PR brings those changes back.

I also fixed some more defects related to the certification process:

1. Added a more detailed welcome response.
2. Added a help response with sample requests.
3. Changed "d" to "die" in the dice rolling prompts.
4. Added back in the sample utterances without the word "me" in them, because they are more natural.

# Testing
None.